### PR TITLE
Authentication Changes

### DIFF
--- a/messaging.app/src/main/java/com/qmul/messaging/app/config/SecurityConfig.java
+++ b/messaging.app/src/main/java/com/qmul/messaging/app/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -19,25 +20,20 @@ public class SecurityConfig {
     }
 
     @Bean
-    public AuthenticationManager authenticationManager(
-            AuthenticationConfiguration authConfig) throws Exception {
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
         return authConfig.getAuthenticationManager();
     }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable())
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/authentication/**"))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/authentication/**").permitAll()
                         .requestMatchers("/messages/**").authenticated()
                         .anyRequest().authenticated()
                 )
-                .formLogin(form -> form
-                        .loginProcessingUrl("/authentication/login")
-                        .defaultSuccessUrl("/messages/global", true)
-                        .permitAll()
-                );
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
         return http.build();
     }
 

--- a/messaging.app/src/main/java/com/qmul/messaging/app/config/SecurityConfig.java
+++ b/messaging.app/src/main/java/com/qmul/messaging/app/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.qmul.messaging.app.config;
 
 import org.springframework.context.annotation.*;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -17,15 +19,23 @@ public class SecurityConfig {
     }
 
     @Bean
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration authConfig) throws Exception {
+        return authConfig.getAuthenticationManager();
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/authentication/register").permitAll()
+                        .requestMatchers("/authentication/**").permitAll()
                         .requestMatchers("/messages/**").authenticated()
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form
-                        .defaultSuccessUrl("/messages/global")
+                        .loginProcessingUrl("/authentication/login")
+                        .defaultSuccessUrl("/messages/global", true)
                         .permitAll()
                 );
         return http.build();

--- a/messaging.app/src/main/java/com/qmul/messaging/app/controller/AuthenticationController.java
+++ b/messaging.app/src/main/java/com/qmul/messaging/app/controller/AuthenticationController.java
@@ -2,14 +2,17 @@ package com.qmul.messaging.app.controller;
 
 import com.qmul.messaging.app.model.Users;
 import com.qmul.messaging.app.repository.UsersRepository;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -43,18 +46,30 @@ public class AuthenticationController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody Map<String, String> request) {
+    public ResponseEntity<?> login(@RequestBody Map<String, String> request, HttpSession session) {
         String username = request.get("username");
         String password = request.get("password");
         try {
             Authentication authentication = authenticationManager.authenticate(
                     new UsernamePasswordAuthenticationToken(username, password)
             );
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(authentication);
+            SecurityContextHolder.setContext(context);
+            session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
+            session.setAttribute("username", username);
             return ResponseEntity.ok("Login successful");
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid username or password");
         }
     }
-    
+
+    //to be removed for production use, only for testing authentication
+    @GetMapping("/session")
+    public ResponseEntity<?> checkSession(HttpSession session) {
+        Object username = session.getAttribute("username");
+        return ResponseEntity.ok("sessionId: " + session.getId() + ", username: " + username);
+    }
+
+
 }

--- a/messaging.app/src/main/java/com/qmul/messaging/app/controller/AuthenticationController.java
+++ b/messaging.app/src/main/java/com/qmul/messaging/app/controller/AuthenticationController.java
@@ -2,16 +2,17 @@ package com.qmul.messaging.app.controller;
 
 import com.qmul.messaging.app.model.Users;
 import com.qmul.messaging.app.repository.UsersRepository;
-import lombok.Data;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/authentication")
@@ -27,9 +28,9 @@ public class AuthenticationController {
     private AuthenticationManager authenticationManager;
 
     @PostMapping("/register")
-    public ResponseEntity<?> register(
-            @RequestParam String username,
-            @RequestParam String password) {
+    public ResponseEntity<?> register(@RequestBody Map<String, String> request) {
+        String username = request.get("username");
+        String password = request.get("password");
         if (usersRepository.existsByUsername(username)) {
             return ResponseEntity.badRequest().body("Username is already in use.");
         }
@@ -42,15 +43,18 @@ public class AuthenticationController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(
-            @RequestParam String username,
-            @RequestParam String password) {
-        Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(username, password)
-        );
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-        return ResponseEntity.ok("Login successful");
+    public ResponseEntity<?> login(@RequestBody Map<String, String> request) {
+        String username = request.get("username");
+        String password = request.get("password");
+        try {
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(username, password)
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            return ResponseEntity.ok("Login successful");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid username or password");
+        }
     }
     
 }

--- a/messaging.app/src/main/java/com/qmul/messaging/app/controller/AuthenticationController.java
+++ b/messaging.app/src/main/java/com/qmul/messaging/app/controller/AuthenticationController.java
@@ -52,16 +52,5 @@ public class AuthenticationController {
         SecurityContextHolder.getContext().setAuthentication(authentication);
         return ResponseEntity.ok("Login successful");
     }
-
-    @Data
-    static class RegisterRequest {
-        private String username;
-        private String password;
-    }
-
-    @Data
-    static class LoginRequest {
-        private String username;
-        private String password;
-    }
+    
 }


### PR DESCRIPTION
Various changes to rectify early issues with authentication, added a homogenous login endpoint for readability, removed unnecessary code by reverting to a more readable non static format.

New Edits:
CSRF (cross site request forgery) protection enabled for most endpoints, disables only those from /authentication.
Session policy is to always create a new session, may adjust to be IF_REQUIRED after experimentation in the future.
Removed form login configuration entirely - all requests for development now have to be made through POSTMAN (or equivalent) by first logging in and then being able to access other endpoints.
Login method added to handle user authentication and session management.
- uses authenticationManager to authenticate the user - spring security component that performs authentication
- UsernamePasswordAuthenticationToken: encapsulates a username and password provided by a user for authentication
- SecurityContext: holds users authentication details. SecurityContextHolder - central place for managing security-related information (actual store).
SecurityContext is saved in the HTTP session refer to session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context)
Endpoint for checking session authentication added - to be removed in production code.