### PR TITLE
Potential fix for code scanning alert no. 6: Disabled Spring CSRF protection

### DIFF
--- a/messaging.app/src/main/java/com/qmul/messaging/app/config/SecurityConfig.java
+++ b/messaging.app/src/main/java/com/qmul/messaging/app/config/SecurityConfig.java
@@ -50,7 +50,9 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(csrf -> csrf.disable())
+                .csrf(csrf -> csrf
+                        .ignoringRequestMatchers("/authentication/**") // Optionally exclude specific endpoints
+                )
                 .exceptionHandling(exceptions -> exceptions
                         .authenticationEntryPoint(new Http403ForbiddenEntryPoint())
                 )


### PR DESCRIPTION
Potential fix for [https://github.com/S0LD13R-CMD/Messaging-App/security/code-scanning/6](https://github.com/S0LD13R-CMD/Messaging-App/security/code-scanning/6)

To fix the issue, CSRF protection should be re-enabled in the `securityFilterChain` method. This involves removing the `csrf.disable()` call and configuring CSRF protection appropriately. If certain endpoints need to bypass CSRF protection (e.g., for APIs), Spring Security provides mechanisms to customize CSRF handling, such as using request matchers to exclude specific endpoints.

**Steps to fix:**
1. Remove the `csrf.disable()` call from the `securityFilterChain` method.
2. Optionally, configure CSRF protection to exclude specific endpoints if necessary using `csrf.ignoringRequestMatchers()`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
